### PR TITLE
feat: allow redis password to be empty

### DIFF
--- a/src/newrelic_logging/__init__.py
+++ b/src/newrelic_logging/__init__.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 # Integration definitions
 
-VERSION         = "2.0.0"
+VERSION         = "2.2.0"
 NAME            = "salesforce-exporter"
 PROVIDER        = "newrelic-labs"
 COLLECTOR_NAME  = "newrelic-salesforce-exporter"

--- a/src/newrelic_logging/cache.py
+++ b/src/newrelic_logging/cache.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from . import CacheException
 from .config import Config
-from .telemetry import print_info
+from .telemetry import print_info, print_warn
 
 
 CONFIG_CACHE_ENABLED = 'cache_enabled'
@@ -63,7 +63,7 @@ class BackendFactory:
         password = config.get(CONFIG_REDIS_PASSWORD)
 
         if not password:
-            raise CacheException('missing redis password')
+            print_warn('missing Redis password, connecting without a password')
 
         password_display = "XXXXXX"
 

--- a/src/tests/test_cache.py
+++ b/src/tests/test_cache.py
@@ -264,66 +264,6 @@ class TestBackendFactory(unittest.TestCase):
         self.assertTrue(hasattr(r, 'ssl'))
         self.assertEqual(r.ssl, True)
 
-    def test_new_backend_raises_cache_exception_given_missing_redis_password(self):
-        '''
-        new_backend() raises a CacheException given the Redis password is missing
-        given: an instance configuration
-        when: new_backend() is called
-        and when: the Redis password is missing
-        then: raise a CacheException
-        '''
-
-        # setup
-        def redis_connect(**kwargs):
-            return SimpleNamespace(**kwargs)
-
-        config = mod_config.Config({
-            'redis': {
-                'host': 'foo',
-                'port': 1234,
-                'db_number': 2,
-                'ssl': True,
-            }
-        })
-
-        # execute / verify
-        with self.assertRaises(CacheException) as _:
-            f = cache.BackendFactory()
-            _ = f.new_backend(
-                config,
-                redis_connector=redis_connect,
-            )
-
-    def test_new_backend_raises_cache_exception_given_empty_redis_password(self):
-        '''
-        new_backend() raises a CacheException given the Redis password is empty
-        given: an instance configuration
-        when: new_backend() is called
-        and when: the Redis password is empty
-        then: raise a CacheException
-        '''
-
-        # setup
-        def redis_connect(**kwargs):
-            return SimpleNamespace(**kwargs)
-
-        config = mod_config.Config({
-            'redis': {
-                'host': 'foo',
-                'port': 1234,
-                'db_number': 2,
-                'password': '',
-                'ssl': True,
-            }
-        })
-
-        # execute / verify
-        with self.assertRaises(CacheException) as _:
-            f = cache.BackendFactory()
-            _ = f.new_backend(
-                config,
-                redis_connector=redis_connect,
-            )
 
 class TestBufferedAddSetCache(unittest.TestCase):
     def test_check_or_set_true_when_item_exists(self):


### PR DESCRIPTION
## Updates

* Allow the Redis password to be empty as it is not needed in some environments
* Added warning when password is empty
* Bumped integration version number.