### PR TITLE
fix: remove trailing comma that mistakenly created a tuple

### DIFF
--- a/src/newrelic_logging/auth.py
+++ b/src/newrelic_logging/auth.py
@@ -107,7 +107,7 @@ class Authenticator:
         subject = self.auth_data['subject']
         audience = self.auth_data['audience']
         exp = int((
-            datetime.utcnow() + timedelta(minutes=self.auth_data['exp_offset']),
+            datetime.utcnow() + timedelta(minutes=self.auth_data['exp_offset'])
         ).timestamp())
 
         with open(private_key_file, 'r') as f:


### PR DESCRIPTION
## Fixes
* Resolves #31 by removing trailing comma that accidentally created a tuple