### PR TITLE
feat: add support for running queries with the tooling api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,8 @@ queries:
   env:
     end_date: "now()"
     start_date: "now(timedelta(minutes=-60))"
+- query: "SELECT FullName FROM EntityDefinition WHERE Label='Opportunity'"
+  api_name: tooling
 ```
 
 #### Query configuration
@@ -1331,6 +1333,32 @@ query to execute.
 
 The `api_ver` attribute can be used to customize the version of the Salesforce
 API that the exporter should use when executing query API calls.
+
+##### `api_name`
+
+| Description | Valid Values | Required | Default |
+| --- | --- | --- | --- |
+| The name of the Salesforce Platform API to use  | `rest` / `tooling` | N | `rest` |
+
+The `api_name` attribute can be used to specify the name of the Salesforce
+Platform API that the exporter should use when executing query API calls.
+
+When the `api_name` attribute is not set or when it is set to the value `rest`,
+the [ReST API](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_rest.htm)
+will be used to execute the
+[SOQL](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm)
+query.
+
+When the `api_name` attribute is set to `tooling`, the
+[Tooling API](https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_api_tooling.htm)
+will be used to execute the
+[SOQL](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm)
+query.
+
+Specifying any other value will cause an error and the exporter will terminate.
+
+**NOTE:** Not all queries can be executed with both APIs. Ensure that the query
+being used is appropriate for the specified Salesforce Platform API.
 
 ##### `id`
 

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -50,6 +50,8 @@ queries:
     start_date: "now(timedelta(minutes=-60))"
   api_ver: "58.0"
   timestamp_attr: StartDate
+- query: "SELECT FullName FROM EntityDefinition WHERE Label='Opportunity'"
+  api_name: tooling
 newrelic:
   data_format: events
   api_endpoint: US

--- a/src/newrelic_logging/__init__.py
+++ b/src/newrelic_logging/__init__.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 # Integration definitions
 
-VERSION         = "2.3.0"
+VERSION         = "2.4.0"
 NAME            = "salesforce-exporter"
 PROVIDER        = "newrelic-labs"
 COLLECTOR_NAME  = "newrelic-salesforce-exporter"

--- a/src/newrelic_logging/query/__init__.py
+++ b/src/newrelic_logging/query/__init__.py
@@ -30,11 +30,13 @@ class Query:
         query: str,
         options: Config,
         api_ver: str = None,
+        api_name: str = None,
     ):
         self.api = api
         self.query = query
         self.options = options
         self.api_ver = api_ver
+        self.api_name = api_name
 
     def get(self, key: str, default = None):
         return self.options.get(key, default)
@@ -47,7 +49,12 @@ class Query:
         session: Session,
     ):
         print_info(f'Running query {self.query}...')
-        response = self.api.query(session, self.query, self.api_ver)
+        response = self.api.query(
+            session,
+            self.query,
+            self.api_ver,
+            self.api_name,
+        )
 
         if not is_valid_records_response(response):
             print_warn(f'no records returned for query {self.query}')
@@ -124,5 +131,6 @@ class QueryFactory:
                 self.get_env(qp),
             ).replace(' ', '+'),
             Config(qp),
-            qp.get('api_ver', None)
+            qp.get('api_ver', None),
+            qp.get('api_name', None),
         )

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -41,6 +41,7 @@ class ApiStub:
         self.limits_result = limits_result
         self.soql = None
         self.query_api_ver = None
+        self.query_api_name = None
         self.next_records_url = None
         self.limits_api_ver = None
         self.log_file_path = None
@@ -54,9 +55,16 @@ class ApiStub:
 
         self.authenticator.authenticate(session)
 
-    def query(self, session: Session, soql: str, api_ver: str = None) -> dict:
+    def query(
+        self,
+        session: Session,
+        soql: str,
+        api_ver: str = None,
+        api_name: str = None,
+    ) -> dict:
         self.soql = soql
         self.query_api_ver = api_ver
+        self.query_api_name = api_name
 
         if self.raise_error:
             raise SalesforceApiException()


### PR DESCRIPTION
**Adds**
* Support `api_name` attribute in query configuration with values `rest` and `tooling`
* Updated `query()` API logic to support querying via [Salesforce Tooling API](https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_api_tooling.htm)
* Updated `config_sample.yml` with example usage
* Updated documentation