### PR TITLE
feat: add OAuth 2.0 client_credentials grant type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,8 @@ SOQL result sets as well.
 
 ### Authentication
 
-The exporter supports the [OAuth 2.0 Username-Password flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_username_password_flow.htm&type=5)
+The exporter supports the [OAuth 2.0 Username-Password flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_username_password_flow.htm&type=5),
+the [OAuth 2.0 Client Credentials flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5),
 and the
 [OAuth 2.0 JWT Bearer flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm&type=5)
 for gaining access to the ReST API via a
@@ -1024,6 +1025,70 @@ export SF_CLIENT_ID="ABCDEFG1234567"
 export SF_CLIENT_SECRET="1123581321abc=="
 export SF_USERNAME="pat"
 export SF_PASSWORD="My5fPa55w0rd"
+```
+
+#### OAuth 2.0 Client Credentials Flow
+
+For the [OAuth 2.0 Client Credentials Flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5),
+the following parameters are required.
+
+##### `grant_type`
+
+The `grant_type` for the OAuth 2.0 Client Credentials Flow _must_ be set to
+`client_credentials` (case-sensitive).
+
+The grant type can also be specified using the `{auth_env_prefix}SF_GRANT_TYPE`
+environment variable.
+
+##### `client_id`
+
+| Description | Valid Values | Required | Default |
+| --- | --- | --- | --- |
+| Consumer key of the connected app | string | Y | N/a |
+
+This parameter specifies the **consumer key** of the connected app. To access
+this value, navigate to "Manage Consumer Details" when viewing the Connected App
+details.
+
+The client ID can also be specified using the `{auth_env_prefix}SF_CLIENT_ID`
+environment variable.
+
+##### `client_secret`
+
+| Description | Valid Values | Required | Default |
+| --- | --- | --- | --- |
+| Consumer secret of the connected app | string | Y | N/a |
+
+This parameter specifies the **consumer secret** of the connected app. To access
+this value, navigate to "Manage Consumer Details" when viewing the Connected App
+details.
+
+The client secret can also be specified using the
+`{auth_env_prefix}SF_CLIENT_SECRET` environment variable.
+
+##### Example
+
+Below is an example OAuth 2.0 Client Credentials Flow configuration in the
+[`auth`](#auth) attribute of the [instance arguments](#instance-arguments)
+attribute of the [instance configuration parameter](#instance-configuration-parameters).
+
+```yaml
+token_url: https://my.salesforce.test/services/oauth2/token
+# ... other instance arguments ...
+auth:
+  grant_type: client_credentials
+  client_id: "ABCDEFG1234567"
+  client_secret: "1123581321abc=="
+```
+
+Below is an example OAuth 2.0 Client Credentials Flow configuration using
+environment variables with _no prefix_ from a `bash` shell.
+
+```bash
+export SF_TOKEN_URL="https://my.salesforce.test/services/oauth2/token"
+export SF_GRANT_TYPE="client_credentials"
+export SF_CLIENT_ID="ABCDEFG1234567"
+export SF_CLIENT_SECRET="1123581321abc=="
 ```
 
 #### OAuth 2.0 JWT Bearer Flow

--- a/src/newrelic_logging/auth.py
+++ b/src/newrelic_logging/auth.py
@@ -196,6 +196,38 @@ class Authenticator:
         except RequestException as e:
             raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
 
+    def authenticate_with_client_credentials(self, session: Session) -> None:
+        client_id = self.auth_data['client_id']
+        client_secret = self.auth_data['client_secret']
+
+        params = {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json"
+        }
+
+        try:
+            print_info(f'retrieving salesforce token at {self.token_url}')
+            resp = session.post(
+                self.token_url,
+                params=params,
+                headers=headers,
+                timeout=self.request_timeout,
+            )
+            if resp.status_code != 200:
+                raise LoginException(f'salesforce token request failed. status-code:{resp.status_code}, reason: {resp.reason}')
+
+            self.store_auth(resp.json())
+        except ConnectionError as e:
+            raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
+        except RequestException as e:
+            raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
+
     def authenticate(self, session: Session) -> None:
         if self.data_cache and self.load_auth_from_cache():
             return
@@ -204,6 +236,11 @@ class Authenticator:
         if oauth_type == 'password':
             self.authenticate_with_password(session)
             print_info('Correctly authenticated with user/pass flow')
+            return
+
+        if oauth_type == 'client_credentials':
+            self.authenticate_with_client_credentials(session)
+            print_info('Correctly authenticated with client credentials flow')
             return
 
         self.authenticate_with_jwt(session)
@@ -228,6 +265,19 @@ def validate_oauth_config(auth: dict) -> dict:
 
     if not auth['password']:
         raise ConfigException('password', 'missing OAuth password')
+
+    return auth
+
+
+def validate_client_credentials_config(auth: dict) -> dict:
+    if not auth['client_id']:
+        raise ConfigException('client_id', 'missing OAuth client id')
+
+    if not auth['client_secret']:
+        raise ConfigException(
+            'client_secret',
+            'missing OAuth client secret',
+        )
 
     return auth
 
@@ -273,6 +323,16 @@ def make_auth_from_config(auth: Config) -> dict:
             'password': auth.get('password', env_var_name=SF_PASSWORD),
         })
 
+    if grant_type == 'client_credentials':
+        return validate_client_credentials_config({
+            'grant_type': grant_type,
+            'client_id': auth.get('client_id', env_var_name=SF_CLIENT_ID),
+            'client_secret': auth.get(
+                'client_secret',
+                env_var_name=SF_CLIENT_SECRET,
+            ),
+        })
+
     if grant_type == 'urn:ietf:params:oauth:grant-type:jwt-bearer':
         exp_offset = auth.get(
             'expiration_offset',
@@ -302,6 +362,13 @@ def make_auth_from_env(config: Config) -> dict:
             'client_secret': config.getenv(SF_CLIENT_SECRET),
             'username': config.getenv(SF_USERNAME),
             'password': config.getenv(SF_PASSWORD),
+        })
+
+    if grant_type == 'client_credentials':
+        return validate_client_credentials_config({
+            'grant_type': grant_type,
+            'client_id': config.getenv(SF_CLIENT_ID),
+            'client_secret': config.getenv(SF_CLIENT_SECRET),
         })
 
     if grant_type == 'urn:ietf:params:oauth:grant-type:jwt-bearer':

--- a/src/tests/test_factory.py
+++ b/src/tests/test_factory.py
@@ -204,6 +204,89 @@ class TestFactory(unittest.TestCase):
         self.assertTrue('password' in auth_data)
         self.assertEqual(auth_data['password'], 'beepboop')
 
+    def test_new_authenticator_returns_new_authenticator_from_config_with_client_credentials(self):
+        '''
+        new_authenticator() returns a new Authenticator configured from the instance config when grant_type is client_credentials
+        given: an instance configuration
+        and given: a data cache
+        when: new_authenticator() is called
+        and when: the data cache is None
+        and when: the 'auth' property exists with grant_type client_credentials
+        then: return a new Authenticator configured from the 'auth' property
+        '''
+
+        # setup
+        config = mod_config.Config({
+            'token_url': 'https://my.salesforce.test',
+            'auth': {
+                'grant_type': 'client_credentials',
+                'client_id': '12345',
+                'client_secret': '56789',
+            }
+        })
+
+        # execute
+        f = factory.Factory()
+        authenticator = f.new_authenticator(config, None)
+
+        # verify
+        self.assertEqual(authenticator.token_url, 'https://my.salesforce.test')
+        self.assertIsNone(authenticator.data_cache)
+        self.assertIsNone(authenticator.request_timeout)
+
+        auth_data = authenticator.auth_data
+
+        self.assertIsNotNone(auth_data)
+        self.assertTrue('grant_type' in auth_data)
+        self.assertEqual(auth_data['grant_type'], 'client_credentials')
+        self.assertTrue('client_id' in auth_data)
+        self.assertEqual(auth_data['client_id'], '12345')
+        self.assertTrue('client_secret' in auth_data)
+        self.assertEqual(auth_data['client_secret'], '56789')
+        self.assertFalse('username' in auth_data)
+        self.assertFalse('password' in auth_data)
+
+    @patch.dict(os.environ, {
+        'SF_TOKEN_URL': 'https://my.salesforce.test',
+        'SF_GRANT_TYPE': 'client_credentials',
+        'SF_CLIENT_ID': 'ABCDEF',
+        'SF_CLIENT_SECRET': 'GHIJKL',
+    })
+    def test_new_authenticator_returns_new_authenticator_from_env_with_client_credentials(self):
+        '''
+        new_authenticator() returns a new Authenticator configured from environment variables when grant_type is client_credentials
+        given: an instance configuration
+        and given: a data cache
+        when: new_authenticator() is called
+        and when: the data cache is None
+        and when: SF_GRANT_TYPE is client_credentials
+        then: return a new Authenticator configured from the environment
+        '''
+
+        # setup
+        config = mod_config.Config({})
+
+        # execute
+        f = factory.Factory()
+        authenticator = f.new_authenticator(config, None)
+
+        # verify
+        self.assertEqual(authenticator.token_url, 'https://my.salesforce.test')
+        self.assertIsNone(authenticator.data_cache)
+        self.assertIsNone(authenticator.request_timeout)
+
+        auth_data = authenticator.auth_data
+
+        self.assertIsNotNone(auth_data)
+        self.assertTrue('grant_type' in auth_data)
+        self.assertEqual(auth_data['grant_type'], 'client_credentials')
+        self.assertTrue('client_id' in auth_data)
+        self.assertEqual(auth_data['client_id'], 'ABCDEF')
+        self.assertTrue('client_secret' in auth_data)
+        self.assertEqual(auth_data['client_secret'], 'GHIJKL')
+        self.assertFalse('username' in auth_data)
+        self.assertFalse('password' in auth_data)
+
     @patch.dict(os.environ, {
         'SF_TOKEN_URL': 'https://my.salesforce.test',
         'SF_GRANT_TYPE': 'password',


### PR DESCRIPTION
Implements the client credentials flow alongside the existing password and JWT bearer flows, allowing authentication without a username/password.